### PR TITLE
feat: add signal parameter support for sendSignal and onSignal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "genshin-ts",
-  "version": "0.1.0",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "genshin-ts",
-      "version": "0.1.0",
+      "version": "0.1.6",
+      "license": "MIT",
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.6.2",
         "chokidar": "^3.6.0",
@@ -31,6 +32,14 @@
         "@ianvs/prettier-plugin-sort-imports": "^4.3.1",
         "@types/node": "^24.10.1",
         "@types/semver": "^7.7.1",
+        "@typescript-eslint/eslint-plugin": "^8.47.0",
+        "@typescript-eslint/parser": "^8.47.0",
+        "eslint": "^9.39.1",
+        "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-prettier": "^5.5.4",
+        "prettier": "^3.6.2"
+      },
+      "peerDependencies": {
         "@typescript-eslint/eslint-plugin": "^8.47.0",
         "@typescript-eslint/parser": "^8.47.0",
         "eslint": "^9.39.1",

--- a/src/compiler/ir_to_gia_transform/index.ts
+++ b/src/compiler/ir_to_gia_transform/index.ts
@@ -330,6 +330,26 @@ export function irToGia(ir: IRDocument, opts: IrToGiaOptions): Uint8Array {
       if (nameArg) {
         setClientExecLiteralArgValue(giaNode, 0, 0, nodeType, nameArg.type, nameArg.value)
       }
+      // Create input pins for signal parameters so graph.connect can find them
+      // Signal name is an exec literal (not a data pin), so data pins start at index 0
+      if (nodeType === 'send_signal') {
+        const args = irNode.args ?? []
+        for (let i = 1; i < args.length; i++) {
+          const arg = args[i]
+          if (!arg) continue
+          if (arg.type === 'conn') {
+            const connType = (arg as ConnectionArgument).value.type as ScalarType
+            const pinType = baseNodeType(connType)
+            if (pinType) {
+              const p = new Pin(giaNode.ConcreteId!, 3, i - 1)
+              p.setType(pinType)
+              giaNode.pins.push(p)
+            }
+          } else if (isValueArg(arg)) {
+            setArgValue(giaNode, i, i, nodeType, arg)
+          }
+        }
+      }
       return true
     }
 
@@ -403,6 +423,8 @@ export function irToGia(ir: IRDocument, opts: IrToGiaOptions): Uint8Array {
       case 'create_prefab':
       case 'create_prefab_group':
         return idx >= 4 ? idx + 1 : idx // hole at 4
+      case 'send_signal':
+        return idx > 0 ? idx - 1 : idx // signal name is exec literal, data pins shift by -1
       default:
         return idx
     }

--- a/src/definitions/nodes.ts
+++ b/src/definitions/nodes.ts
@@ -6806,14 +6806,25 @@ export class ServerExecutionFlowFunctions {
    * @param signalName Only literal string is supported
    *
    * 信号名（仅支持字面量字符串）
+   *
+   * @param params Signal parameters to pass, matching the signal's registered parameters in the editor
+   *
+   * 信号参数，需与编辑器信号管理器中注册的参数一一对应
    */
-  sendSignal(signalName: StrValue): void {
+  sendSignal(signalName: StrValue, ...params: any[]): void {
     const signalNameObj = ensureLiteralStr(signalName, 'signalName')
+    const paramObjs = params.map(p => {
+      const genericType = matchTypes([
+        'float', 'int', 'bool', 'config_id', 'entity', 'faction',
+        'guid', 'prefab_id', 'str', 'vec3', 'dict'
+      ], p)
+      return parseValue(p, genericType)
+    })
     this.registry.registerNode({
       id: 0,
       type: 'exec',
       nodeType: 'send_signal',
-      args: [signalNameObj]
+      args: [signalNameObj, ...paramObjs]
     })
   }
 

--- a/src/runtime/core.ts
+++ b/src/runtime/core.ts
@@ -28,6 +28,7 @@ import {
   dict,
   ensureLiteralStr,
   enumeration,
+  generic,
   list,
   localVariable,
   value,
@@ -178,13 +179,18 @@ export type ServerGraphApi<
    * GSTS Note: You still need to register the signal in the signal manager in the editor; Using signal distribution can avoid some large loop triggering load limits, which can be used for performance optimization
    *
    * GSTS 注: 你仍然需要在编辑器内的信号管理器注册信号; 使用信号分发能够避免一些大循环触发负载限制, 可用于性能优化
+   *
+   * @param signalParamCount Number of signal parameters to read from the monitor_signal event. Parameters are exposed as evt.signalParam0, evt.signalParam1, etc.
+   *
+   * 信号参数数量。参数通过 evt.signalParam0, evt.signalParam1 等属性访问，类型为 generic，需调用 .asType() 转换
    */
   onSignal(
     signalName: string,
     handler: (
       evt: ServerEventPayloadsByMode<Mode>['monitorSignal'],
       f: ServerExecutionFlowFunctionsForLang<Vars, Lang, Mode>
-    ) => void
+    ) => void,
+    signalParamCount?: number
   ): ServerGraphApi<Vars, Lang, Mode>
 }
 
@@ -851,10 +857,30 @@ function server<Vars extends VariablesDefinition = VariablesDefinition>(
       handler: (
         evt: ServerEventPayloadsByMode<ResolvedMode>['monitorSignal'],
         f: ServerExecutionFlowFunctionsForLang<Vars, ResolvedLang, ResolvedMode>
-      ) => void
+      ) => void,
+      signalParamCount?: number
     ) {
       const signalNameObj = ensureLiteralStr(signalName, 'signalName')
-      runHandler('monitorSignal', handler, [signalNameObj])
+      const wrappedHandler = signalParamCount
+        ? (
+            evt: ServerEventPayloadsByMode<ResolvedMode>['monitorSignal'],
+            f: ServerExecutionFlowFunctionsForLang<Vars, ResolvedLang, ResolvedMode>
+          ) => {
+            for (let i = 0; i < signalParamCount; i++) {
+              const paramRecord: MetaCallRecord = {
+                id: 0,
+                type: 'event',
+                nodeType: 'monitor_signal',
+                args: [signalNameObj]
+              }
+              const paramValue = new generic()
+              paramValue.markPin(paramRecord, `signalParam_${i}`, 3 + i)
+              ;(evt as any)[`signalParam${i}`] = paramValue
+            }
+            handler(evt, f)
+          }
+        : handler
+      runHandler('monitorSignal', wrappedHandler, [signalNameObj])
       return this
     }
   }

--- a/src/runtime/server_globals.ts
+++ b/src/runtime/server_globals.ts
@@ -402,7 +402,7 @@ export type ServerGlobalFactories = {
     items?: RuntimeParameterValueTypeMap[T][] | null | 0
   ) => RuntimeReturnValueTypeMap[`${T}_list`]
   print: (string: StrValue) => void
-  send: (signalName: StrValue) => void
+  send: (signalName: StrValue, ...params: any[]) => void
   player: (playerId: IntValue) => PlayerEntity
   setTimeout: (handler: (evt: unknown, f: unknown) => void, delayMs?: FloatValue) => string
   setInterval: (handler: (evt: unknown, f: unknown) => void, delayMs?: FloatValue) => string
@@ -553,9 +553,9 @@ function makeFactories(): ServerGlobalFactories {
       ensureServerCtx('print')
       gsts.f.printString(string)
     },
-    send: (signalName: StrValue) => {
+    send: (signalName: StrValue, ...params: any[]) => {
       ensureServerCtx('send')
-      gsts.f.sendSignal(signalName)
+      gsts.f.sendSignal(signalName, ...params)
     },
     player: (playerId: IntValue) => {
       ensureServerCtx('player')


### PR DESCRIPTION
- sendSignal now accepts ...params for passing signal parameters
- onSignal now accepts signalParamCount to specify expected params count
- Signal params are exposed as evt.signalParam0, evt.signalParam1, etc.
- GIA transform creates proper input pins for send_signal parameters
- GIA transform remaps data connection indices for send_signal (signal name is exec literal, data pins start at 0)