### PR TITLE
修复：send_signal 列表类型参数引脚缺失 / Fix: send_signal missing data pins for list-type parameters

### DIFF
--- a/src/compiler/ir_to_gia_transform/index.ts
+++ b/src/compiler/ir_to_gia_transform/index.ts
@@ -341,8 +341,8 @@ export function irToGia(ir: IRDocument, opts: IrToGiaOptions): Uint8Array {
           const arg = args[i]
           if (!arg) continue
           if (arg.type === 'conn') {
-            const connType = (arg as ConnectionArgument).value.type as ScalarType
-            const pinType = baseNodeType(connType)
+            const connType = (arg as ConnectionArgument).value.type
+            const pinType = valueTypeToNodeType(connType)
             if (pinType) {
               const p = new Pin(giaNode.ConcreteId!, 3, i - 1)
               p.setType(pinType)


### PR DESCRIPTION
# 🔧 fix: 修复 `send_signal` 列表类型信号参数引脚缺失问题

## 修改

修复 `send_signal` 节点中列表类型参数（`int_list`、`bool_list` 等）的数据引脚未被创建的问题。

**文件**: `src/compiler/ir_to_gia_transform/index.ts`（第 344-345 行）

### 修改内容

```diff
- const connType = (arg as ConnectionArgument).value.type as ScalarType
- const pinType = baseNodeType(connType)
+ const connType = (arg as ConnectionArgument).value.type
+ const pinType = valueTypeToNodeType(connType)
```

## 根因

`send_signal` 分支为信号参数创建引脚时使用了 `baseNodeType(connType)`，该函数只处理 10 种标量类型，`int_list`/`bool_list` 等列表类型不匹配任何 `case`，导致隐式返回 `undefined`，引脚被跳过创建。

同一文件中的 `valueTypeToNodeType` 函数已正确支持 `_list` 后缀（先剥离 `_list`，委托给 `baseNodeType`，再包装为列表节点类型）。`monitor_signal` 分支也通过 `connTypeInfoToNodeType` → `valueTypeToNodeType` 正确使用了它，只有 `send_signal` 遗漏了。

## 验证

- ✅ `npm run build` — TypeScript 编译零错误
- ✅ `npm test` — 测试通过（唯一失败为已有问题 `other.literal.ts: "cannot infer list type"`，与本次修改无关）
- ✅ 标量类型（`str`/`int`/`bool`/`float`）零影响：`valueTypeToNodeType` 对非 `_list` 类型最终委托给 `baseNodeType`，行为不变
- ✅ 列表类型（`int_list`/`bool_list`）现在正确创建为 `{ t: 'l', i: baseNodeType(base) }`，与 `monitor_signal` 行为一致

## 相关 commit

- `44a9c23` — 引入 `send_signal` 分支（当时使用 `baseNodeType`）
- `0fa3e1d` — 新增 `valueTypeToNodeType` 和 `connTypeInfoToNodeType` 但未更新 `send_signal`

## 检查清单

- [x] 修改最小化（2 行，1 个文件）
- [x] 向后兼容（标量类型行为不变）
- [x] 与 `monitor_signal` 行为一致
- [x] 构建已验证
- [x] 测试已执行

---

# 🔧 fix: `send_signal` list-type signal parameter pins are missing

## Changes

Fix data pins not being created for list-type parameters (`int_list`, `bool_list`, etc.) in `send_signal` nodes.

**File**: `src/compiler/ir_to_gia_transform/index.ts` (lines 344-345)

### Diff

```diff
- const connType = (arg as ConnectionArgument).value.type as ScalarType
- const pinType = baseNodeType(connType)
+ const connType = (arg as ConnectionArgument).value.type
+ const pinType = valueTypeToNodeType(connType)
```

## Root Cause

The `send_signal` branch used `baseNodeType(connType)` to create data pins, but this function only handles 10 scalar types. List types like `int_list`/`bool_list` match no `case` and implicitly return `undefined`, causing the pin creation to be skipped.

The `valueTypeToNodeType` function in the same file already handles the `_list` suffix correctly (strips `_list`, delegates to `baseNodeType`, wraps as list node type). The `monitor_signal` branch already uses it via `connTypeInfoToNodeType` → `valueTypeToNodeType`. Only `send_signal` was missed.

## Verification

- ✅ `npm run build` — TypeScript zero errors
- ✅ `npm test` — Tests pass (the only failure is pre-existing: `other.literal.ts: "cannot infer list type"`, unrelated to this change)
- ✅ Scalar types (`str`/`int`/`bool`/`float`) unaffected: `valueTypeToNodeType` delegates to `baseNodeType` for non-`_list` types, same behavior
- ✅ List types (`int_list`/`bool_list`) now correctly create `{ t: 'l', i: baseNodeType(base) }`, consistent with `monitor_signal`

## Related Commits

- `44a9c23` — Introduced the `send_signal` branch using `baseNodeType`
- `0fa3e1d` — Added `valueTypeToNodeType` and `connTypeInfoToNodeType` but missed `send_signal`

## Checklist

- [x] Minimal change (2 lines in 1 file)
- [x] Backward compatible (scalar types unchanged)
- [x] Consistent with `monitor_signal` branch
- [x] Build verified
- [x] Tests run