### PR TITLE
fix: 修复注入 / 信号提取阶段因全量字段扫描导致的严重性能退化 / fix: severe performance degradation in injection / signal extraction from full field scan

### DIFF
--- a/src/cli/gil_signals.ts
+++ b/src/cli/gil_signals.ts
@@ -197,7 +197,10 @@ export function extractSignalsFromGil(params: {
 
   try {
     const { payload, fields } = readGilPayloadFields(params.gilPath)
-    const entries = parseSignalEntries(payload, fields)
+    const signalFields = fields.filter(function (f) {
+      return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+    })
+    const entries = parseSignalEntries(payload, signalFields)
 
     writeGeneratedFile(params.outPath, buildSignalsSource(entries))
     return { status: 'ok', outPath: params.outPath, count: entries.length }

--- a/src/injector/index.ts
+++ b/src/injector/index.ts
@@ -94,7 +94,10 @@ export function createInjector(options?: { protoPath?: string; lang?: string }):
     const fields: LenField[] = []
     const nodeGraphBlobFields: LenField[] = []
     parseMessage(payload, 0, payload.length, 0, 0, 0, 0, 0, 0, 0, fields, { nodeGraphBlobFields })
-    patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields }, t)
+    const signalFields = fields.filter(function (f) {
+      return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+    })
+    patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields: signalFields }, t)
     const matches = findNodeGraphTargets(
       payload,
       nodeGraphBlobFields.length ? nodeGraphBlobFields : fields,


### PR DESCRIPTION
# 🔧 fix: 修复注入 / 信号提取阶段因全量字段扫描导致的严重性能退化

## 修改

修复注入阶段（`patchSignalNodeIds`）和信号提取阶段（`extractSignalsFromGil`）遍历全部 ~93k protobuf 字段并对每个字段做 `readFieldBytes` 二进制扫描导致的性能问题——注入从 >15 分钟卡死降至 ~300ms。

**文件：**

1. `src/injector/index.ts`（第 93-103 行）
2. `src/cli/gil_signals.ts`（第 197-205 行）

### 修改内容

#### 1. `src/injector/index.ts`

```diff
  const payload = input.gilBytes.slice(20, -4)
  const fields: LenField[] = []
  const nodeGraphBlobFields: LenField[] = []
  parseMessage(payload, 0, payload.length, 0, 0, 0, 0, 0, 0, 0, fields, { nodeGraphBlobFields })
- patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields }, t)
+ const signalFields = fields.filter(function (f) {
+   return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+ })
+ patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields: signalFields }, t)
```

#### 2. `src/cli/gil_signals.ts`

```diff
  const { payload, fields } = readGilPayloadFields(params.gilPath)
- const entries = parseSignalEntries(payload, fields)
+ const signalFields = fields.filter(function (f) {
+   return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+ })
+ const entries = parseSignalEntries(payload, signalFields)
```

## 根因

`buildSignalNodeIdMapFromFields` 和 `parseSignalEntries` 都遍历 `parseMessage` 输出的全部 ~93k 个平坦字段，对每个做 `readFieldBytes(containerBytes, 107)`——该函数**线性扫描整个字段的二进制数据**来寻找 field 107。

在 ~93k 字段中仅 121 个（0.13%）包含 field 107。对剩余 99.87% 的字段，扫描完整个字段数据后只返回 `undefined`，属于纯浪费。累积 ~93k 次二进制线性扫描×每个字段数千字节，导致注入在 Node.js 中挂起 >15 分钟。

### 数据结构推导逻辑

`.gil` 的二进制结构通过实测反向推导得出，外层包装路径（`p0=10 → p1=2 → p2=1`）经实测验证。其中 `CompositeDef` 内部字段（`field=107: Type`、`field=4: Id`、`field=102: inputs`、`field=103: outputs`）参考仓库内 `gia.proto` 对 `CompositeDef` 消息体的定义确认。

`.gil` 根消息在 `field=10` 下是一个列表，每个条目通过 depth-1 的 field 编号区分：`field=1` 对应 `NodeGraphWrapper` 概念（类比 `gia.proto` 的 field=13），`field=2` 对应 `CompositeDefWrapper` 概念（类比 `gia.proto` 的 field=14）。信号是 `CompositeDef` 的一种 Type，field=107 在 `CompositeDef` 消息体中正是 `Type` 字段。因此信号容器在 protobuf 中的完整路径为 `field=10 → field=2 (CompositeDefWrapper) → field=1 (inner.def) → field=1 (CompositeDef 实例自身)`，在该实例内部 `field=107` 存储信号定义。

```
根消息
  └── field=10: graphList
        ├── field=1 → NodeGraphWrapper（类比 gia.proto field=13）
        │     └── field=1: inner.graph → NodeGraph 原始 bytes
        │
        └── field=2 → CompositeDefWrapper（类比 gia.proto field=14）
              └── field=1: inner.def → CompositeDef 实例 (field=1)
                    ├── field=4:   Id
                    ├── field=107: Type（信号定义）
                    ├── field=102: inputs（信号参数）
                    └── field=103: outputs（send/monitor 判定）
```

在该路径下过滤 `depth=3, p0=10, p1=2, p2=1, field=1`，在项目中实测的地图上为 100% 命中（121/121）。

> **说明：** 筛选条件在项目当前实测数据上达到 121/121 完全命中，但未覆盖所有可能的地图类型。若遇到不符合该路径的信号容器，或作者对 `.gil` 包装层有更准确的 schema 理解，欢迎指正修改。

## 过滤精度

| 过滤 | 字段数 | 命中 | 误扫 |
|------|--------|------|------|
| 无 | 93,580 | 121 | 93,459 |
| `depth===3` | 4,561 | 121 | 4,440 |
| **本 PR（精确 p 链）** | **121** | **121** | **0** |

## 验证

- ✅ `npx tsc --noEmit` — TypeScript 编译零错误
- ✅ 实测注入 6 GIA 文件 ~313ms（patched）vs >15 分钟（unpatched）
- ✅ 信号提取结果不变（11 条信号，patched 与 unpatched 一致）

## 检查清单

- [x] 修改最小化（2 个文件，各 4 行过滤代码）
- [x] 与已有 `isNodeGraphBlobField` 模式一致
- [x] 编译已验证
- [x] 实测性能已验证

---

# 🔧 fix: severe performance degradation in injection / signal extraction from full field scan

## Changes

Fix `patchSignalNodeIds` (injection) and `extractSignalsFromGil` (signal extraction) iterating over all ~93k protobuf fields and performing `readFieldBytes` binary scan on each — injection drops from >15 min hang to ~300ms.

**Files:**

1. `src/injector/index.ts` (lines 93-103)
2. `src/cli/gil_signals.ts` (lines 197-205)

### Diffs

#### 1. `src/injector/index.ts`

```diff
  const payload = input.gilBytes.slice(20, -4)
  const fields: LenField[] = []
  const nodeGraphBlobFields: LenField[] = []
  parseMessage(payload, 0, payload.length, 0, 0, 0, 0, 0, 0, 0, fields, { nodeGraphBlobFields })
- patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields }, t)
+ const signalFields = fields.filter(function (f) {
+   return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+ })
+ patchSignalNodeIds(newGraph, input.gilBytes, { payload, fields: signalFields }, t)
```

#### 2. `src/cli/gil_signals.ts`

```diff
  const { payload, fields } = readGilPayloadFields(params.gilPath)
- const entries = parseSignalEntries(payload, fields)
+ const signalFields = fields.filter(function (f) {
+   return f.depth === 3 && f.p0 === 10 && f.p1 === 2 && f.p2 === 1 && f.field === 1
+ })
+ const entries = parseSignalEntries(payload, signalFields)
```

## Root Cause

Both `buildSignalNodeIdMapFromFields` and `parseSignalEntries` iterate over ALL ~93k flat fields from `parseMessage`, calling `readFieldBytes(containerBytes, 107)` on each — a **linear binary scan** of the full field data.

Only 121 of ~93k fields (0.13%) contain field 107. For the remaining 99.87%, the scan traverses the complete field data only to return `undefined` — pure waste. ~93k binary linear scans × thousands of bytes per field causes the injection to hang >15 minutes in Node.js.

### Structural Derivation

The `.gil` binary structure was reverse-engineered through empirical measurement; the outer wrapper path (`p0=10 → p1=2 → p2=1`) is validated by test data. The `CompositeDef` internal fields (`field=107: Type`, `field=4: Id`, `field=102: inputs`, `field=103: outputs`) are confirmed by referencing the `CompositeDef` message definition in `gia.proto`.

The `.gil` root message has a list under `field=10`. Each entry is discriminated by its depth-1 field number: `field=1` maps to `NodeGraphWrapper` (analogous to `gia.proto` field=13), `field=2` maps to `CompositeDefWrapper` (analogous to `gia.proto` field=14). Signals are a Type of `CompositeDef`, and field=107 in the `CompositeDef` message body is exactly the `Type` field. The full protobuf path for signal containers is therefore `field=10 → field=2 (CompositeDefWrapper) → field=1 (inner.def) → field=1 (CompositeDef instance)`, inside which `field=107` stores the signal definition.

```
Root message
  └── field=10: graphList
        ├── field=1 → NodeGraphWrapper (analogous to gia.proto field=13)
        │     └── field=1: inner.graph → NodeGraph raw bytes
        │
        └── field=2 → CompositeDefWrapper (analogous to gia.proto field=14)
              └── field=1: inner.def → CompositeDef instance (field=1)
                    ├── field=4:   Id
                    ├── field=107: Type (signal definition)
                    ├── field=102: inputs (signal params)
                    └── field=103: outputs (send/monitor detection)
```

Filtering by `depth=3, p0=10, p1=2, p2=1, field=1` on actual maps in the project yields 100% precision (121/121 hits).

> **Note:** The filter achieves 121/121 hits on the project's current test data, but does not cover all possible map types. If you encounter signal containers that don't match this path, or have a more accurate understanding of the `.gil` wrapper schema, please feel free to correct or revise.

## Filtering Precision

| Filter | Fields | Hits | Waste |
|--------|--------|------|-------|
| None | 93,580 | 121 | 93,459 |
| `depth===3` | 4,561 | 121 | 4,440 |
| **This PR** | **121** | **121** | **0** |

## Verification

- ✅ `npx tsc --noEmit` — TypeScript zero errors
- ✅ Measured: 6 GIA injection ~313ms (patched) vs >15 min (unpatched)
- ✅ Signal extraction output unchanged (11 signals, identical patched/unpatched)

## Checklist

- [x] Minimal change (2 files, 4 lines of filter code each)
- [x] Consistent with existing `isNodeGraphBlobField` pattern
- [x] Build verified
- [x] Performance verified with real measurement